### PR TITLE
Add a dependency to produce Prometheus metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,12 @@
             <artifactId>jaxb-runtime</artifactId>
             <version>2.3.2</version>
         </dependency>
-
+        <!-- Enable metrics in Prometheus format -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>1.1.4</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,7 @@ http-server:
 management:
   endpoints:
     web:
+      expose: prometheus
       exposure:
         include: "*"
 


### PR DESCRIPTION
Solves issue #42.

Check also https://github.com/systelab/prometheus-monitoring for instructions to enable Grafana.