### PR TITLE
Mapstruct remove redundant component-model tag

### DIFF
--- a/src/main/java/com/systelab/seed/features/allergy/controller/dto/AllergyMapper.java
+++ b/src/main/java/com/systelab/seed/features/allergy/controller/dto/AllergyMapper.java
@@ -3,7 +3,7 @@ package com.systelab.seed.features.allergy.controller.dto;
 import com.systelab.seed.features.allergy.model.Allergy;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring")
+@Mapper
 public interface AllergyMapper {
 
     Allergy fromRequestDTO(AllergyRequestDTO dto);

--- a/src/main/java/com/systelab/seed/features/patient/allergy/controller/dto/PatientAllergyMapper.java
+++ b/src/main/java/com/systelab/seed/features/patient/allergy/controller/dto/PatientAllergyMapper.java
@@ -3,7 +3,7 @@ package com.systelab.seed.features.patient.allergy.controller.dto;
 import com.systelab.seed.features.patient.allergy.model.PatientAllergy;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring")
+@Mapper
 public interface PatientAllergyMapper {
 
     PatientAllergy fromRequestDTO(PatientAllergyRequestDTO dto);

--- a/src/main/java/com/systelab/seed/features/patient/controller/dto/PatientMapper.java
+++ b/src/main/java/com/systelab/seed/features/patient/controller/dto/PatientMapper.java
@@ -3,7 +3,7 @@ package com.systelab.seed.features.patient.controller.dto;
 import com.systelab.seed.features.patient.model.Patient;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring")
+@Mapper
 public interface PatientMapper {
 
     Patient fromRequestDTO(PatientRequestDTO dto);

--- a/src/main/java/com/systelab/seed/features/user/controller/dto/UserMapper.java
+++ b/src/main/java/com/systelab/seed/features/user/controller/dto/UserMapper.java
@@ -3,7 +3,7 @@ package com.systelab.seed.features.user.controller.dto;
 import com.systelab.seed.features.user.model.User;
 import org.mapstruct.Mapper;
 
-@Mapper(componentModel = "spring")
+@Mapper
 public interface UserMapper {
 
     User fromRequestDTO(UserRequestDTO dto);


### PR DESCRIPTION
Remove componentModel spring from mappers as it is already defined in pom.xml 
<arg>-Amapstruct.defaultComponentModel=spring</arg>